### PR TITLE
Update data

### DIFF
--- a/data/island_exceptions.csv
+++ b/data/island_exceptions.csv
@@ -1,0 +1,2 @@
+Island,Exception
+Provincetown,Hyannis

--- a/data/metro_areas.csv
+++ b/data/metro_areas.csv
@@ -1,16 +1,16 @@
-Metro Area,Income,Country,IsNationalCapital
-Los Angeles,75629,United States,No
-New York City,77399,United States,No
-Chicago,70009,United States,No
-Boston,118453,United States,No
-Provincetown,212306,United States,No
-Portsmouth,82210,United States,No
-Hyannis,148042,United States,No
-Nauru,19000,Nauru,Yes
-Funafuti,30495,Tuvalu,Yes
-Majuro,12011,Marshall Islands,Yes
-Pohnpei,18736,Federated States of Micronesia,Yes
-Kwajalien,14956,Marshall Islands,No
-Kosrae,24025,Federated States of Micronesia,No
-Chuuk,15613,Federated States of Micronesia,No
-Yap,20789,Federated States of Micronesia,No
+Metro Area,Income,Country,IsNationalCapital,isIsland
+Los Angeles,75629,United States,No,No
+New York City,77399,United States,No,No
+Chicago,70009,United States,No,No
+Boston,118453,United States,No,No
+Provincetown,212306,United States,No,Yes
+Portsmouth,82210,United States,No,No
+Hyannis,148042,United States,No,No
+Nauru,19000,Nauru,Yes,Yes
+Funafuti,30495,Tuvalu,Yes,Yes
+Majuro,12011,Marshall Islands,Yes,Yes
+Pohnpei,18736,Federated States of Micronesia,Yes,Yes
+Kwajalien,14956,Marshall Islands,No,Yes
+Kosrae,24025,Federated States of Micronesia,No,Yes
+Chuuk,15613,Federated States of Micronesia,No,Yes
+Yap,20789,Federated States of Micronesia,No,Yes

--- a/data/metro_areas.csv
+++ b/data/metro_areas.csv
@@ -1,16 +1,16 @@
-Metro Area,Percent business,Percent leisure,Income,Country,IsNationalCapital
-Los Angeles,12,88,75629,United States,No
-New York City,12,88,77346,United States,No
-Chicago,15,85,70009,United States,No
-Boston,12,88,118453,United States,No
-Provincetown,6,94,212306,United States,No
-Portsmouth,12,88,82210,United States,No
-Hyannis,12,88,148042,United States,No
-Nauru,67,33,19000,Nauru,Yes
-Funafuti,67,33,30495,Tuvalu,Yes
-Majuro,50,50,12011,Marshall Islands,Yes
-Pohnpei,33,67,18736,Federated States of Micronesia,Yes
-Kwajalien,67,33,14956,Marshall Islands,No
-Kosrae,50,50,24025,Federated States of Micronesia,No
-Chuuk,50,50,15613,Federated States of Micronesia,No
-Yap,50,50,20789,Federated States of Micronesia,No
+Metro Area,Income,Country,IsNationalCapital
+Los Angeles,75629,United States,No
+New York City,77399,United States,No
+Chicago,70009,United States,No
+Boston,118453,United States,No
+Provincetown,212306,United States,No
+Portsmouth,82210,United States,No
+Hyannis,148042,United States,No
+Nauru,19000,Nauru,Yes
+Funafuti,30495,Tuvalu,Yes
+Majuro,12011,Marshall Islands,Yes
+Pohnpei,18736,Federated States of Micronesia,Yes
+Kwajalien,14956,Marshall Islands,No
+Kosrae,24025,Federated States of Micronesia,No
+Chuuk,15613,Federated States of Micronesia,No
+Yap,20789,Federated States of Micronesia,No

--- a/data/populations.csv
+++ b/data/populations.csv
@@ -1,18 +1,18 @@
-Metro area,Year,Population,Notes
-Boston,2020,4873019,"Boston includes Suffolk, Middlesex, Norfolk, Essex, and Plymouth counties.  Income is average family income."
-Provincetown,2020,33664,Provincetown’s summer population is 60000; took wealthiest family income in Middlesex County to backfill the 56k who don’t live there full time for income
-Portsmouth,2020,287721,Includes half of Rockingham County population and all of Strafford County
-Los Angeles,2019,14643573,"Thank you to CensusReporter for providing urbanized area data here.  Apparently the national average percentage of travel that is for business is 12, though this was impossible to verify. "
-Hyannis,2020,341638,Summer population of roughly 250000.  Just Barnstable County (exc. Provincetown)
-Chicago,2020,7421160,"Includes Cook, DuPage, Lake, and Lake (IN) counties"
-New York City,2019,16530972,"Includes NYC, Bergen County, Hudston County, Passaic County, Westchester County, Middlesex County, Somerset County, Essex County, Union County, Morris County, and Nassau County"
-Provincetown,1920,4246,
-Majuro,2010,27797,
-Pohnpei,2010,34789,https://www.fsmstatistics.fm/wp-content/uploads/2019/02/1998_HIES_Main_Analysis_Report.pdf
-Kosrae,2010,6616,
-Yap,2010,7371,
-Chuuk,2010,36158,
-Funafuti,2017,6320,http://prdrse4all.spc.int/system/files/tuvalu_hies_report_2010.pdf
-Nauru,2020,10000,"https://spccfpstore1.blob.core.windows.net/digitallibrary-docs/files/9c/9c62fdc3882f7fa1a03d24da772c2da0.pdf?sv=2015-12-11&sr=b&sig=JcD%2F5Mr7zYd%2FJedq%2BL7QfWHTt44OSpC5ENfJLOIgw8w%3D&se=2022-04-11T17%3A23%3A28Z&sp=r&rscc=public%2C%20max-age%3D864000%2C%20max-stale%3D86400&rsct=application%2Fpdf&rscd=inline%3B%20filename%3D""Nauru_2006_HIES_Report.pdf"""
-Kwajalien,2000,14500,
-Kosrae,1980,5491,
+Metro area,Year,Population,Notes,
+Boston,2020,4873019,"Boston includes Suffolk, Middlesex, Norfolk, Essex, and Plymouth counties.  Income is average family income.",
+Provincetown,2020,33664,Provincetown’s summer population is 60000, took wealthiest family income in Middlesex County to backfill the 56k who don’t live there full time for income
+Portsmouth,2020,287721,Includes half of Rockingham County population and all of Strafford County,
+Los Angeles,2019,14643573,"Thank you to CensusReporter for providing urbanized area data here.  Apparently the national average percentage of travel that is for business is 12, though this was impossible to verify. ",
+Hyannis,2020,341638,Summer population of roughly 250000.  Just Barnstable County (exc. Provincetown),
+Chicago,2020,7421160,"Includes Cook, DuPage, Lake, and Lake (IN) counties",
+New York City,2019,16869301,"Includes NYC, Bergen County, Hudson County, Passaic County, Westchester County, Middlesex County, Somerset County, Essex County, Union County, Morris County, Rockland County, and Nassau County",
+Provincetown,1920,4246,,
+Majuro,2010,27797,,
+Pohnpei,2010,34789,https://www.fsmstatistics.fm/wp-content/uploads/2019/02/1998_HIES_Main_Analysis_Report.pdf,
+Kosrae,2010,6616,,
+Yap,2010,7371,,
+Chuuk,2010,36158,,
+Funafuti,2017,6320,http://prdrse4all.spc.int/system/files/tuvalu_hies_report_2010.pdf,
+Nauru,2020,10000,https://spccfpstore1.blob.core.windows.net/digitallibrary-docs/files/9c/9c62fdc3882f7fa1a03d24da772c2da0.pdf ,
+Kwajalien,2000,14500,,
+Kosrae,1980,5491,,

--- a/data/tourists.csv
+++ b/data/tourists.csv
@@ -2,10 +2,10 @@ Metro area,Year,Visitors,Notes
 Boston,2019,5932719,Assume 2/13 domestic visitors fly and all international visitors fly
 Provincetown,2020,1000,Total guess
 Portsmouth,2020,10000,Total guess
-Los Angeles,2018,15933333.3333333,https://www.discoverlosangeles.com/sites/default/files/2019-05/2018%20QUICK%20FACTS.pdf  – assume all international visitors fly and 1/3rd of domestic ones dottps://www.discoverlosangeles.com/sites/default/files/2019-05/2018%20QUICK%20FACTS.pdf
+Los Angeles,2018,15933333,https://www.discoverlosangeles.com/sites/default/files/2019-05/2018%20QUICK%20FACTS.pdf  – assume all international visitors fly and 1/3rd of domestic ones dottps://www.discoverlosangeles.com/sites/default/files/2019-05/2018%20QUICK%20FACTS.pdf
 Hyannis,2020,10000,Total guess
 Chicago,2013,6140000,Assume 1/5th of domestic visitors fly and all international visitors fly
-New York City,2019,20957142.8571429,https://www.baruch.cuny.edu/nycdata/tourism/visitors.htm – assume all international visitors and 1/7th of domestic visitors fly
+New York City,2019,20957143,https://www.baruch.cuny.edu/nycdata/tourism/visitors.htm – assume all international visitors and 1/7th of domestic visitors fly
 Majuro,2018,6761,https://pic.or.jp/ja/wp-content/uploads/2019/07/2018-Annual-Visitor-Arrivals-ReportF.pdf – seems high for Nauru so dividing by 2
 Pohnpei,2013,2238,https://www.fsmstatistics.fm/wp-content/uploads/2019/10/4-FSM-National-Tourism-Policy-Vol-1a_W-Foreword_8July.pdf
 Kosrae,2013,585,
@@ -22,6 +22,6 @@ Pohnpei,2007,2792,https://www.fsmstatistics.fm/wp-content/uploads/2019/10/4-FSM-
 Kosrae,2007,802,
 Yap,2007,4429,
 Chuuk,2007,8024,
-New York City,2013,17614285.7142857,https://www.baruch.cuny.edu/nycdata/tourism/visitors.htm – assume all international visitors and 1/7th of domestic visitors fly
+New York City,2013,17614286,https://www.baruch.cuny.edu/nycdata/tourism/visitors.htm – assume all international visitors and 1/7th of domestic visitors fly
 New York City,2007,14100000,https://www.baruch.cuny.edu/nycdata/tourism/visitors.htm – assume all international visitors and 1/7th of domestic visitors fly
 New York City,2000,11000000,https://www.baruch.cuny.edu/nycdata/tourism/visitors.htm – assume all international visitors and 1/7th of domestic visitors fly

--- a/data/tourists.csv
+++ b/data/tourists.csv
@@ -1,0 +1,27 @@
+Metro area,Year,Visitors,Notes
+Boston,2019,5932719,Assume 2/13 domestic visitors fly and all international visitors fly
+Provincetown,2020,1000,Total guess
+Portsmouth,2020,10000,Total guess
+Los Angeles,2018,15933333.3333333,https://www.discoverlosangeles.com/sites/default/files/2019-05/2018%20QUICK%20FACTS.pdf  – assume all international visitors fly and 1/3rd of domestic ones dottps://www.discoverlosangeles.com/sites/default/files/2019-05/2018%20QUICK%20FACTS.pdf
+Hyannis,2020,10000,Total guess
+Chicago,2013,6140000,Assume 1/5th of domestic visitors fly and all international visitors fly
+New York City,2019,20957142.8571429,https://www.baruch.cuny.edu/nycdata/tourism/visitors.htm – assume all international visitors and 1/7th of domestic visitors fly
+Majuro,2018,6761,https://pic.or.jp/ja/wp-content/uploads/2019/07/2018-Annual-Visitor-Arrivals-ReportF.pdf – seems high for Nauru so dividing by 2
+Pohnpei,2013,2238,https://www.fsmstatistics.fm/wp-content/uploads/2019/10/4-FSM-National-Tourism-Policy-Vol-1a_W-Foreword_8July.pdf
+Kosrae,2013,585,
+Yap,2013,3484,
+Chuuk,2013,6408,
+Funafuti,2017,2729,
+Nauru,2016,1519,
+Kwajalien,2020,100,Total guess
+Pohnpei,1997,2794,https://www.fsmstatistics.fm/wp-content/uploads/2019/10/4-FSM-National-Tourism-Policy-Vol-1a_W-Foreword_8July.pdf
+Kosrae,1997,803,
+Yap,1997,4432,
+Chuuk,1997,8029,
+Pohnpei,2007,2792,https://www.fsmstatistics.fm/wp-content/uploads/2019/10/4-FSM-National-Tourism-Policy-Vol-1a_W-Foreword_8July.pdf
+Kosrae,2007,802,
+Yap,2007,4429,
+Chuuk,2007,8024,
+New York City,2013,17614285.7142857,https://www.baruch.cuny.edu/nycdata/tourism/visitors.htm – assume all international visitors and 1/7th of domestic visitors fly
+New York City,2007,14100000,https://www.baruch.cuny.edu/nycdata/tourism/visitors.htm – assume all international visitors and 1/7th of domestic visitors fly
+New York City,2000,11000000,https://www.baruch.cuny.edu/nycdata/tourism/visitors.htm – assume all international visitors and 1/7th of domestic visitors fly


### PR DESCRIPTION
Add tourist numbers to data; remove percent business/leisure - can assume all national capital traffic is business, 88% of population traffic is leisure, and all tourist traffic is leisure

Perhaps: 
Residents spend $0.011 (one point one cents) per dollar of income on air travel
Tourists spend $300 each on air travel
National capital => get an additional 10000 residents who spend $500 each on air travel

