### PR TITLE
Refactor demand curve

### DIFF
--- a/app/models/calculation/demand_curve.rb
+++ b/app/models/calculation/demand_curve.rb
@@ -20,11 +20,7 @@ class Calculation::DemandCurve
   end
 
   def relative_demand_island(distance)
-    if distance < short_threshold_distance
-      short_island(distance)
-    else
-      relative_demand(distance)
-    end
+    short_threshold_distance * 100 / distance
   end
 
   private
@@ -51,10 +47,6 @@ class Calculation::DemandCurve
 
     def short_exponent
       @short_exponent ||= SHORT_EXPONENTS.fetch(@curve_type)
-    end
-
-    def short_island(distance)
-      short_threshold_distance * 100 / distance
     end
 
     def short_significance

--- a/app/models/calculation/demand_curve.rb
+++ b/app/models/calculation/demand_curve.rb
@@ -10,7 +10,7 @@ class Calculation::DemandCurve
     @curve_type = curve_type
   end
 
-  def relative_demand
+  def relative_demand(distance)
     if @distance < short_threshold_distance
       short
     elsif @distance > long_threshold_distance
@@ -20,11 +20,11 @@ class Calculation::DemandCurve
     end
   end
 
-  def relative_demand_island
+  def relative_demand_island(distance)
     if @distance < short_threshold_distance
       short_island
     else
-      relative_demand
+      relative_demand(distance)
     end
   end
 

--- a/app/models/calculation/demand_curve.rb
+++ b/app/models/calculation/demand_curve.rb
@@ -5,24 +5,23 @@ class Calculation::DemandCurve
   SHORT_THRESHOLD_DISTANCES = { :business => 275, :leisure => 400 }
   LONG_THRESHOLD_DISTANCES = { :business => 400, :leisure => 600 }
 
-  def initialize(distance, curve_type)
-    @distance = distance
+  def initialize(curve_type)
     @curve_type = curve_type
   end
 
   def relative_demand(distance)
-    if @distance < short_threshold_distance
-      short
-    elsif @distance > long_threshold_distance
-      long
+    if distance < short_threshold_distance
+      short(distance)
+    elsif distance > long_threshold_distance
+      long(distance)
     else
       moderate
     end
   end
 
   def relative_demand_island(distance)
-    if @distance < short_threshold_distance
-      short_island
+    if distance < short_threshold_distance
+      short_island(distance)
     else
       relative_demand(distance)
     end
@@ -30,8 +29,8 @@ class Calculation::DemandCurve
 
   private
 
-    def long
-      long_threshold_distance * 100 / @distance
+    def long(distance)
+      long_threshold_distance * 100 / distance
     end
 
     def long_threshold_distance
@@ -42,8 +41,8 @@ class Calculation::DemandCurve
       100
     end
 
-    def short
-      short_constant * (@distance ** short_exponent) * short_significance
+    def short(distance)
+      short_constant * (distance ** short_exponent) * short_significance
     end
 
     def short_constant
@@ -54,8 +53,8 @@ class Calculation::DemandCurve
       @short_exponent ||= SHORT_EXPONENTS.fetch(@curve_type)
     end
 
-    def short_island
-      short_threshold_distance * 100 / @distance
+    def short_island(distance)
+      short_threshold_distance * 100 / distance
     end
 
     def short_significance

--- a/app/models/calculation/resident_demand.rb
+++ b/app/models/calculation/resident_demand.rb
@@ -22,9 +22,9 @@ class Calculation::ResidentDemand
 
     def distance_demand(type)
       if origin_market.is_island
-        Calculation::DemandCurve.new(distance, type).relative_demand_island
+        Calculation::DemandCurve.new(distance, type).relative_demand_island(distance)
       else
-        Calculation::DemandCurve.new(distance, type).relative_demand
+        Calculation::DemandCurve.new(distance, type).relative_demand(distance)
       end
     end
 

--- a/app/models/calculation/resident_demand.rb
+++ b/app/models/calculation/resident_demand.rb
@@ -22,9 +22,9 @@ class Calculation::ResidentDemand
 
     def distance_demand(type)
       if origin_market.is_island
-        Calculation::DemandCurve.new(distance, type).relative_demand_island(distance)
+        Calculation::DemandCurve.new(type).relative_demand_island(distance)
       else
-        Calculation::DemandCurve.new(distance, type).relative_demand(distance)
+        Calculation::DemandCurve.new(type).relative_demand(distance)
       end
     end
 

--- a/app/models/calculation/resident_demand.rb
+++ b/app/models/calculation/resident_demand.rb
@@ -20,12 +20,28 @@ class Calculation::ResidentDemand
       end
     end
 
+    def business_demand_curve
+      @business_demand_curve ||= Calculation::DemandCurve.new(:business)
+    end
+
+    def demand_curve(type)
+      if type == :business
+        business_demand_curve
+      elsif type == :leisure
+        leisure_demand_curve
+      end
+    end
+
     def distance_demand(type)
       if origin_market.is_island
-        Calculation::DemandCurve.new(type).relative_demand_island(distance)
+        demand_curve(type).relative_demand_island(distance)
       else
-        Calculation::DemandCurve.new(type).relative_demand(distance)
+        demand_curve(type).relative_demand(distance)
       end
+    end
+
+    def leisure_demand_curve
+      @leisure_demand_curve ||= Calculation::DemandCurve.new(:leisure)
     end
 
     def raw_demand(type)

--- a/app/models/calculation/tourist_demand.rb
+++ b/app/models/calculation/tourist_demand.rb
@@ -17,9 +17,9 @@ class Calculation::TouristDemand
 
     def distance_demand(type)
       if origin_market.is_island
-        Calculation::DemandCurve.new(distance, type).relative_demand_island
+        Calculation::DemandCurve.new(distance, type).relative_demand_island(distance)
       else
-        Calculation::DemandCurve.new(distance, type).relative_demand
+        Calculation::DemandCurve.new(distance, type).relative_demand(distance)
       end
     end
 end

--- a/app/models/calculation/tourist_demand.rb
+++ b/app/models/calculation/tourist_demand.rb
@@ -17,9 +17,9 @@ class Calculation::TouristDemand
 
     def distance_demand(type)
       if origin_market.is_island
-        Calculation::DemandCurve.new(distance, type).relative_demand_island(distance)
+        Calculation::DemandCurve.new(type).relative_demand_island(distance)
       else
-        Calculation::DemandCurve.new(distance, type).relative_demand(distance)
+        Calculation::DemandCurve.new(type).relative_demand(distance)
       end
     end
 end

--- a/app/models/calculation/tourist_demand.rb
+++ b/app/models/calculation/tourist_demand.rb
@@ -5,7 +5,7 @@ class Calculation::TouristDemand
     if origin_market == destination_market
       0
     else
-      airport_population / 100.0 * distance_demand(:leisure) * border_multiplier
+      airport_population / 100.0 * distance_demand * border_multiplier
     end
   end
 
@@ -15,11 +15,15 @@ class Calculation::TouristDemand
       domestic? ? 1 : 1/3.0
     end
 
-    def distance_demand(type)
+    def demand_curve
+      @demand_curve ||= Calculation::DemandCurve.new(:leisure)
+    end
+
+    def distance_demand
       if origin_market.is_island
-        Calculation::DemandCurve.new(type).relative_demand_island(distance)
+        demand_curve.relative_demand_island(distance)
       else
-        Calculation::DemandCurve.new(type).relative_demand(distance)
+        demand_curve.relative_demand(distance)
       end
     end
 end

--- a/test/models/calculation/demand_curve_test.rb
+++ b/test/models/calculation/demand_curve_test.rb
@@ -1,8 +1,11 @@
 require "test_helper"
 
 class Calculation::DemandCurveTest < ActiveSupport::TestCase
+  business_subject = Calculation::DemandCurve.new(:business)
+  leisure_subject = Calculation::DemandCurve.new(:leisure)
+  
   test "demand is zero for a business trip of zero miles" do
-    subject = create_business_subject(0)
+    subject = business_subject
     expected = 0
     delta = 0.001
 
@@ -11,7 +14,7 @@ class Calculation::DemandCurveTest < ActiveSupport::TestCase
 
   test "demand is between 0 and 100 for a business trip between zero and SHORT_THRESHOLD_DISTANCE miles" do
     distance = Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:business) / 2
-    subject = create_business_subject(distance)
+    subject = business_subject
 
     assert 0 < subject.relative_demand(distance)
     assert subject.relative_demand(distance) < 100
@@ -19,8 +22,8 @@ class Calculation::DemandCurveTest < ActiveSupport::TestCase
 
   test "demand is closer to zero for a short business trip than to 100 for a long business trip less than SHORT_THRESHOLD_DISTANCE" do
     distance_delta = Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:business) / 100
-    short_subject = create_business_subject(distance_delta)
-    long_subject = create_business_subject(Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:business) - distance_delta)
+    short_subject = business_subject
+    long_subject = business_subject
 
     short_difference = short_subject.relative_demand(distance_delta)
     long_difference = 100 - long_subject.relative_demand(Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:business) - distance_delta)
@@ -30,7 +33,7 @@ class Calculation::DemandCurveTest < ActiveSupport::TestCase
 
   test "demand is 100 for a business trip of SHORT_THRESHOLD_DISTANCE" do
     distance = Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:business)
-    subject = create_business_subject(distance)
+    subject = business_subject
     expected = 100
     delta = 0.001
 
@@ -39,7 +42,7 @@ class Calculation::DemandCurveTest < ActiveSupport::TestCase
 
   test "demand is 100 for a business trip between SHORT_THRESHOLD_DISTANCE and LONG_THRESHOLD_DISTANCE" do
     distance = (Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:business) + Calculation::DemandCurve::LONG_THRESHOLD_DISTANCES.fetch(:business)) / 2
-    subject = create_business_subject(distance)
+    subject = business_subject
     expected = 100
     delta = 0.001
 
@@ -48,14 +51,14 @@ class Calculation::DemandCurveTest < ActiveSupport::TestCase
 
   test "demand is between 0 and 100 for a business trip longer than LONG_THRESHOLD_DISTANCE" do
     distance = Calculation::DemandCurve::LONG_THRESHOLD_DISTANCES.fetch(:business) + 1
-    subject = create_business_subject(distance)
+    subject = business_subject
 
     assert 0 < subject.relative_demand(distance)
     assert subject.relative_demand(distance) < 100
   end
 
   test "demand is between 0 and 100 for a business trip of half of the earth's circumference" do
-    subject = create_business_subject(12500)
+    subject = business_subject
 
     assert 0 < subject.relative_demand(12500)
     assert subject.relative_demand(12500) < 100
@@ -63,14 +66,14 @@ class Calculation::DemandCurveTest < ActiveSupport::TestCase
 
   test "demand is greater than 100 for an island business trip of shorter than SHORT_THRESHOLD_DISTANCE" do
     distance = Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:business) / 2
-    subject = create_business_subject(distance)
+    subject = business_subject
 
     assert 100 < subject.relative_demand_island(distance)
   end
 
   test "demand is equal to 100 for an island business trip of between SHORT_THRESHOLD_DISTANCE and LONG_THRESHOLD_DISTANCE" do
     distance = (Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:business) + Calculation::DemandCurve::LONG_THRESHOLD_DISTANCES.fetch(:business)) / 2
-    subject = create_business_subject(distance)
+    subject = business_subject
     expected = 100
     delta = 0.001
 
@@ -79,14 +82,14 @@ class Calculation::DemandCurveTest < ActiveSupport::TestCase
 
   test "demand is less than 100 for an island business trip of more than LONG_THRESHOLD_DISTANCE" do
     distance = Calculation::DemandCurve::LONG_THRESHOLD_DISTANCES.fetch(:business) + 1
-    subject = create_business_subject(distance)
+    subject = business_subject
 
     assert 0 < subject.relative_demand_island(distance)
     assert subject.relative_demand_island(distance) < 100
   end
 
   test "demand is zero for a leisure trip of zero miles" do
-    subject = create_leisure_subject(0)
+    subject = leisure_subject
     expected = 0
     delta = 0.001
 
@@ -95,7 +98,7 @@ class Calculation::DemandCurveTest < ActiveSupport::TestCase
 
   test "demand is between 0 and 100 for a leisure trip between zero and SHORT_THRESHOLD_DISTANCE miles" do
     distance = Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:leisure) / 2
-    subject = create_leisure_subject(distance)
+    subject = leisure_subject
 
     assert 0 < subject.relative_demand(distance)
     assert subject.relative_demand(distance) < 100
@@ -103,8 +106,8 @@ class Calculation::DemandCurveTest < ActiveSupport::TestCase
 
   test "demand is closer to zero for a short leisure trip than to 100 for a long leisure trip less than SHORT_THRESHOLD_DISTANCE" do
     distance_delta = Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:leisure) / 100
-    short_subject = create_leisure_subject(distance_delta)
-    long_subject = create_leisure_subject(Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:leisure) - distance_delta)
+    short_subject = leisure_subject
+    long_subject = leisure_subject
 
     short_difference = short_subject.relative_demand(distance_delta)
     long_difference = 100 - long_subject.relative_demand(Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:leisure) - distance_delta)
@@ -114,7 +117,7 @@ class Calculation::DemandCurveTest < ActiveSupport::TestCase
 
   test "demand is 100 for a leisure trip of SHORT_THRESHOLD_DISTANCE" do
     distance = Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:leisure)
-    subject = create_leisure_subject(distance)
+    subject = leisure_subject
     expected = 100
     delta = 0.001
 
@@ -123,7 +126,7 @@ class Calculation::DemandCurveTest < ActiveSupport::TestCase
 
   test "demand is 100 for a leisure trip between SHORT_THRESHOLD_DISTANCE and LONG_THRESHOLD_DISTANCE" do
     distance = (Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:leisure) + Calculation::DemandCurve::LONG_THRESHOLD_DISTANCES.fetch(:leisure)) / 2
-    subject = create_leisure_subject(distance)
+    subject = leisure_subject
     expected = 100
     delta = 0.001
 
@@ -132,14 +135,14 @@ class Calculation::DemandCurveTest < ActiveSupport::TestCase
 
   test "demand is between 0 and 100 for a leisure trip longer than LONG_THRESHOLD_DISTANCE" do
     distance = Calculation::DemandCurve::LONG_THRESHOLD_DISTANCES.fetch(:leisure) + 1
-    subject = create_leisure_subject(distance)
+    subject = leisure_subject
 
     assert 0 < subject.relative_demand(distance)
     assert subject.relative_demand(distance) < 100
   end
 
   test "demand is between 0 and 100 for a leisure trip of half of the earth's circumference" do
-    subject = create_leisure_subject(12500)
+    subject = leisure_subject
 
     assert 0 < subject.relative_demand(12500)
     assert subject.relative_demand(12500) < 100
@@ -147,14 +150,14 @@ class Calculation::DemandCurveTest < ActiveSupport::TestCase
 
   test "demand is greater than 100 for an island leisure trip of shorter than SHORT_THRESHOLD_DISTANCE" do
     distance = Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:leisure) / 2
-    subject = create_leisure_subject(distance)
+    subject = leisure_subject
 
     assert 100 < subject.relative_demand_island(distance)
   end
 
   test "demand is equal to 100 for an island leisure trip of between SHORT_THRESHOLD_DISTANCE and LONG_THRESHOLD_DISTANCE" do
     distance = (Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:leisure) + Calculation::DemandCurve::LONG_THRESHOLD_DISTANCES.fetch(:leisure)) / 2
-    subject = create_leisure_subject(distance)
+    subject = leisure_subject
     expected = 100
     delta = 0.001
 
@@ -163,17 +166,9 @@ class Calculation::DemandCurveTest < ActiveSupport::TestCase
 
   test "demand is less than 100 for an island leisure trip of more than LONG_THRESHOLD_DISTANCE" do
     distance = Calculation::DemandCurve::LONG_THRESHOLD_DISTANCES.fetch(:leisure) + 1
-    subject = create_leisure_subject(distance)
+    subject = leisure_subject
 
     assert 0 < subject.relative_demand_island(distance)
     assert subject.relative_demand_island(distance) < 100
-  end
-
-  def create_business_subject(distance)
-    Calculation::DemandCurve.new(distance, :business)
-  end
-
-  def create_leisure_subject(distance)
-    Calculation::DemandCurve.new(distance, :leisure)
   end
 end

--- a/test/models/calculation/demand_curve_test.rb
+++ b/test/models/calculation/demand_curve_test.rb
@@ -6,14 +6,15 @@ class Calculation::DemandCurveTest < ActiveSupport::TestCase
     expected = 0
     delta = 0.001
 
-    assert_in_delta(subject.relative_demand, expected, delta)
+    assert_in_delta(subject.relative_demand(0), expected, delta)
   end
 
   test "demand is between 0 and 100 for a business trip between zero and SHORT_THRESHOLD_DISTANCE miles" do
-    subject = create_business_subject(Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:business) / 2)
+    distance = Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:business) / 2
+    subject = create_business_subject(distance)
 
-    assert 0 < subject.relative_demand
-    assert subject.relative_demand < 100
+    assert 0 < subject.relative_demand(distance)
+    assert subject.relative_demand(distance) < 100
   end
 
   test "demand is closer to zero for a short business trip than to 100 for a long business trip less than SHORT_THRESHOLD_DISTANCE" do
@@ -21,61 +22,67 @@ class Calculation::DemandCurveTest < ActiveSupport::TestCase
     short_subject = create_business_subject(distance_delta)
     long_subject = create_business_subject(Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:business) - distance_delta)
 
-    short_difference = short_subject.relative_demand
-    long_difference = 100 - long_subject.relative_demand
+    short_difference = short_subject.relative_demand(distance_delta)
+    long_difference = 100 - long_subject.relative_demand(Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:business) - distance_delta)
 
     assert short_difference < long_difference
   end
 
   test "demand is 100 for a business trip of SHORT_THRESHOLD_DISTANCE" do
-    subject = create_business_subject(Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:business))
+    distance = Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:business)
+    subject = create_business_subject(distance)
     expected = 100
     delta = 0.001
 
-    assert_in_delta(subject.relative_demand, expected, delta)
+    assert_in_delta(subject.relative_demand(distance), expected, delta)
   end
 
   test "demand is 100 for a business trip between SHORT_THRESHOLD_DISTANCE and LONG_THRESHOLD_DISTANCE" do
-    subject = create_business_subject((Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:business) + Calculation::DemandCurve::LONG_THRESHOLD_DISTANCES.fetch(:business)) / 2)
+    distance = (Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:business) + Calculation::DemandCurve::LONG_THRESHOLD_DISTANCES.fetch(:business)) / 2
+    subject = create_business_subject(distance)
     expected = 100
     delta = 0.001
 
-    assert_in_delta(subject.relative_demand, expected, delta)
+    assert_in_delta(subject.relative_demand(distance), expected, delta)
   end
 
   test "demand is between 0 and 100 for a business trip longer than LONG_THRESHOLD_DISTANCE" do
-    subject = create_business_subject(Calculation::DemandCurve::LONG_THRESHOLD_DISTANCES.fetch(:business) + 1)
+    distance = Calculation::DemandCurve::LONG_THRESHOLD_DISTANCES.fetch(:business) + 1
+    subject = create_business_subject(distance)
 
-    assert 0 < subject.relative_demand
-    assert subject.relative_demand < 100
+    assert 0 < subject.relative_demand(distance)
+    assert subject.relative_demand(distance) < 100
   end
 
   test "demand is between 0 and 100 for a business trip of half of the earth's circumference" do
     subject = create_business_subject(12500)
 
-    assert 0 < subject.relative_demand
-    assert subject.relative_demand < 100
+    assert 0 < subject.relative_demand(12500)
+    assert subject.relative_demand(12500) < 100
   end
 
   test "demand is greater than 100 for an island business trip of shorter than SHORT_THRESHOLD_DISTANCE" do
-    subject = create_business_subject(Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:business) / 2)
+    distance = Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:business) / 2
+    subject = create_business_subject(distance)
 
-    assert 100 < subject.relative_demand_island
+    assert 100 < subject.relative_demand_island(distance)
   end
 
   test "demand is equal to 100 for an island business trip of between SHORT_THRESHOLD_DISTANCE and LONG_THRESHOLD_DISTANCE" do
-    subject = create_business_subject((Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:business) + Calculation::DemandCurve::LONG_THRESHOLD_DISTANCES.fetch(:business)) / 2)
+    distance = (Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:business) + Calculation::DemandCurve::LONG_THRESHOLD_DISTANCES.fetch(:business)) / 2
+    subject = create_business_subject(distance)
     expected = 100
     delta = 0.001
 
-    assert_in_delta(subject.relative_demand_island, expected, delta)
+    assert_in_delta(subject.relative_demand_island(distance), expected, delta)
   end
 
   test "demand is less than 100 for an island business trip of more than LONG_THRESHOLD_DISTANCE" do
-    subject = create_business_subject(Calculation::DemandCurve::LONG_THRESHOLD_DISTANCES.fetch(:business) + 1)
+    distance = Calculation::DemandCurve::LONG_THRESHOLD_DISTANCES.fetch(:business) + 1
+    subject = create_business_subject(distance)
 
-    assert 0 < subject.relative_demand_island
-    assert subject.relative_demand_island < 100
+    assert 0 < subject.relative_demand_island(distance)
+    assert subject.relative_demand_island(distance) < 100
   end
 
   test "demand is zero for a leisure trip of zero miles" do
@@ -83,14 +90,15 @@ class Calculation::DemandCurveTest < ActiveSupport::TestCase
     expected = 0
     delta = 0.001
 
-    assert_in_delta(subject.relative_demand, expected, delta)
+    assert_in_delta(subject.relative_demand(0), expected, delta)
   end
 
   test "demand is between 0 and 100 for a leisure trip between zero and SHORT_THRESHOLD_DISTANCE miles" do
-    subject = create_leisure_subject(Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:leisure) / 2)
+    distance = Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:leisure) / 2
+    subject = create_leisure_subject(distance)
 
-    assert 0 < subject.relative_demand
-    assert subject.relative_demand < 100
+    assert 0 < subject.relative_demand(distance)
+    assert subject.relative_demand(distance) < 100
   end
 
   test "demand is closer to zero for a short leisure trip than to 100 for a long leisure trip less than SHORT_THRESHOLD_DISTANCE" do
@@ -98,61 +106,67 @@ class Calculation::DemandCurveTest < ActiveSupport::TestCase
     short_subject = create_leisure_subject(distance_delta)
     long_subject = create_leisure_subject(Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:leisure) - distance_delta)
 
-    short_difference = short_subject.relative_demand
-    long_difference = 100 - long_subject.relative_demand
+    short_difference = short_subject.relative_demand(distance_delta)
+    long_difference = 100 - long_subject.relative_demand(Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:leisure) - distance_delta)
 
     assert short_difference < long_difference
   end
 
   test "demand is 100 for a leisure trip of SHORT_THRESHOLD_DISTANCE" do
-    subject = create_leisure_subject(Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:leisure))
+    distance = Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:leisure)
+    subject = create_leisure_subject(distance)
     expected = 100
     delta = 0.001
 
-    assert_in_delta(subject.relative_demand, expected, delta)
+    assert_in_delta(subject.relative_demand(distance), expected, delta)
   end
 
   test "demand is 100 for a leisure trip between SHORT_THRESHOLD_DISTANCE and LONG_THRESHOLD_DISTANCE" do
-    subject = create_leisure_subject((Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:leisure) + Calculation::DemandCurve::LONG_THRESHOLD_DISTANCES.fetch(:leisure)) / 2)
+    distance = (Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:leisure) + Calculation::DemandCurve::LONG_THRESHOLD_DISTANCES.fetch(:leisure)) / 2
+    subject = create_leisure_subject(distance)
     expected = 100
     delta = 0.001
 
-    assert_in_delta(subject.relative_demand, expected, delta)
+    assert_in_delta(subject.relative_demand(distance), expected, delta)
   end
 
   test "demand is between 0 and 100 for a leisure trip longer than LONG_THRESHOLD_DISTANCE" do
-    subject = create_leisure_subject(Calculation::DemandCurve::LONG_THRESHOLD_DISTANCES.fetch(:leisure) + 1)
+    distance = Calculation::DemandCurve::LONG_THRESHOLD_DISTANCES.fetch(:leisure) + 1
+    subject = create_leisure_subject(distance)
 
-    assert 0 < subject.relative_demand
-    assert subject.relative_demand < 100
+    assert 0 < subject.relative_demand(distance)
+    assert subject.relative_demand(distance) < 100
   end
 
   test "demand is between 0 and 100 for a leisure trip of half of the earth's circumference" do
     subject = create_leisure_subject(12500)
 
-    assert 0 < subject.relative_demand
-    assert subject.relative_demand < 100
+    assert 0 < subject.relative_demand(12500)
+    assert subject.relative_demand(12500) < 100
   end
 
   test "demand is greater than 100 for an island leisure trip of shorter than SHORT_THRESHOLD_DISTANCE" do
-    subject = create_leisure_subject(Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:leisure) / 2)
+    distance = Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:leisure) / 2
+    subject = create_leisure_subject(distance)
 
-    assert 100 < subject.relative_demand_island
+    assert 100 < subject.relative_demand_island(distance)
   end
 
   test "demand is equal to 100 for an island leisure trip of between SHORT_THRESHOLD_DISTANCE and LONG_THRESHOLD_DISTANCE" do
-    subject = create_leisure_subject((Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:leisure) + Calculation::DemandCurve::LONG_THRESHOLD_DISTANCES.fetch(:leisure)) / 2)
+    distance = (Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:leisure) + Calculation::DemandCurve::LONG_THRESHOLD_DISTANCES.fetch(:leisure)) / 2
+    subject = create_leisure_subject(distance)
     expected = 100
     delta = 0.001
 
-    assert_in_delta(subject.relative_demand_island, expected, delta)
+    assert_in_delta(subject.relative_demand_island(distance), expected, delta)
   end
 
   test "demand is less than 100 for an island leisure trip of more than LONG_THRESHOLD_DISTANCE" do
-    subject = create_leisure_subject(Calculation::DemandCurve::LONG_THRESHOLD_DISTANCES.fetch(:leisure) + 1)
+    distance = Calculation::DemandCurve::LONG_THRESHOLD_DISTANCES.fetch(:leisure) + 1
+    subject = create_leisure_subject(distance)
 
-    assert 0 < subject.relative_demand_island
-    assert subject.relative_demand_island < 100
+    assert 0 < subject.relative_demand_island(distance)
+    assert subject.relative_demand_island(distance) < 100
   end
 
   def create_business_subject(distance)

--- a/test/models/calculation/demand_curve_test.rb
+++ b/test/models/calculation/demand_curve_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class Calculation::DemandCurveTest < ActiveSupport::TestCase
   business_subject = Calculation::DemandCurve.new(:business)
   leisure_subject = Calculation::DemandCurve.new(:leisure)
-  
+
   test "demand is zero for a business trip of zero miles" do
     subject = business_subject
     expected = 0
@@ -71,17 +71,8 @@ class Calculation::DemandCurveTest < ActiveSupport::TestCase
     assert 100 < subject.relative_demand_island(distance)
   end
 
-  test "demand is equal to 100 for an island business trip of between SHORT_THRESHOLD_DISTANCE and LONG_THRESHOLD_DISTANCE" do
-    distance = (Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:business) + Calculation::DemandCurve::LONG_THRESHOLD_DISTANCES.fetch(:business)) / 2
-    subject = business_subject
-    expected = 100
-    delta = 0.001
-
-    assert_in_delta(subject.relative_demand_island(distance), expected, delta)
-  end
-
-  test "demand is less than 100 for an island business trip of more than LONG_THRESHOLD_DISTANCE" do
-    distance = Calculation::DemandCurve::LONG_THRESHOLD_DISTANCES.fetch(:business) + 1
+  test "demand is less than 100 for an island business trip of more than SHORT_THRESHOLD_DISTANCE" do
+    distance = Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:business) + 1
     subject = business_subject
 
     assert 0 < subject.relative_demand_island(distance)
@@ -155,17 +146,8 @@ class Calculation::DemandCurveTest < ActiveSupport::TestCase
     assert 100 < subject.relative_demand_island(distance)
   end
 
-  test "demand is equal to 100 for an island leisure trip of between SHORT_THRESHOLD_DISTANCE and LONG_THRESHOLD_DISTANCE" do
-    distance = (Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:leisure) + Calculation::DemandCurve::LONG_THRESHOLD_DISTANCES.fetch(:leisure)) / 2
-    subject = leisure_subject
-    expected = 100
-    delta = 0.001
-
-    assert_in_delta(subject.relative_demand_island(distance), expected, delta)
-  end
-
-  test "demand is less than 100 for an island leisure trip of more than LONG_THRESHOLD_DISTANCE" do
-    distance = Calculation::DemandCurve::LONG_THRESHOLD_DISTANCES.fetch(:leisure) + 1
+  test "demand is less than 100 for an island leisure trip of more than SHORT_THRESHOLD_DISTANCE" do
+    distance = Calculation::DemandCurve::SHORT_THRESHOLD_DISTANCES.fetch(:leisure) + 1
     subject = leisure_subject
 
     assert 0 < subject.relative_demand_island(distance)

--- a/test/models/calculation/resident_demand_test.rb
+++ b/test/models/calculation/resident_demand_test.rb
@@ -91,24 +91,24 @@ class Calculation::ResidentDemandTest < ActiveSupport::TestCase
     assert actual_leisure == expected
   end
 
-  test "business demand is equivalent to the destination population when between islands, domestic, and the demand-maximizing distance" do
+  test "business demand is equivalent to the island demand curve when between islands, domestic, and the demand-maximizing distance" do
     pohnpei = Market.find_by!(name: "Pohnpei")
     kosrae = Market.find_by!(name: "Kosrae")
 
     actual = Calculation::ResidentDemand.new(pohnpei.airports.first, kosrae.airports.first, Date.today).business_demand
-    expected = 1000
+    expected = Calculation::DemandCurve.new(:business).relative_demand_island(Calculation::Distance.between_airports(pohnpei.airports.first, kosrae.airports.first)) / 100.0 * kosrae.populations.first.population
 
     assert actual == expected
   end
 
-  test "leisure demand is equivalent to the destination population when between islands, domestic, and the demand-maximizing distance" do
+  test "leisure demand is equivalent to the island demand curve when between islands, domestic, and the demand-maximizing distance" do
     pohnpei = Market.find_by!(name: "Pohnpei")
     micronesia = Market.find_by!(name: "Micronesia")
 
     actual = Calculation::ResidentDemand.new(pohnpei.airports.first, micronesia.airports.last, Date.today).leisure_demand
-    expected = micronesia.populations.first.population
+    expected = Calculation::DemandCurve.new(:leisure).relative_demand_island(Calculation::Distance.between_airports(pohnpei.airports.first, micronesia.airports.last)) / 100.0 * micronesia.populations.first.population
 
-    assert actual == expected
+    assert_in_epsilon actual, expected, 0.000001
   end
 
   test "business demand is halved when the destination is not an island" do
@@ -118,7 +118,7 @@ class Calculation::ResidentDemandTest < ActiveSupport::TestCase
     kosrae = Market.find_by!(name: "Kosrae")
 
     actual = Calculation::ResidentDemand.new(pohnpei.airports.first, kosrae.airports.first, Date.today).business_demand
-    expected = 500
+    expected = Calculation::DemandCurve.new(:business).relative_demand_island(Calculation::Distance.between_airports(pohnpei.airports.first, kosrae.airports.first)) / 100.0 * kosrae.populations.first.population / 2.0
 
     assert actual == expected
   end
@@ -130,9 +130,9 @@ class Calculation::ResidentDemandTest < ActiveSupport::TestCase
     micronesia = Market.find_by!(name: "Micronesia")
 
     actual = Calculation::ResidentDemand.new(pohnpei.airports.first, micronesia.airports.last, Date.today).leisure_demand
-    expected = micronesia.populations.first.population / 2.0
+    expected = Calculation::DemandCurve.new(:leisure).relative_demand_island(Calculation::Distance.between_airports(pohnpei.airports.first, micronesia.airports.last)) / 100.0 * micronesia.populations.first.population / 2.0
 
-    assert actual == expected
+    assert_in_epsilon actual, expected, 0.000001
   end
 
   test "demand is halved when the origin is not an island" do
@@ -159,7 +159,7 @@ class Calculation::ResidentDemandTest < ActiveSupport::TestCase
     kosrae = Market.find_by!(name: "Kosrae")
 
     actual = Calculation::ResidentDemand.new(pohnpei.airports.first, kosrae.airports.first, Date.today).business_demand
-    expected = 1000 / 12.0
+    expected = Calculation::DemandCurve.new(:business).relative_demand_island(Calculation::Distance.between_airports(pohnpei.airports.first, kosrae.airports.first)) / 100.0 * kosrae.populations.first.population / 12.0
 
     assert actual == expected
   end
@@ -171,9 +171,9 @@ class Calculation::ResidentDemandTest < ActiveSupport::TestCase
     micronesia = Market.find_by!(name: "Micronesia")
 
     actual = Calculation::ResidentDemand.new(pohnpei.airports.first, micronesia.airports.last, Date.today).leisure_demand
-    expected = micronesia.populations.first.population / 12.0
+    expected = Calculation::DemandCurve.new(:leisure).relative_demand_island(Calculation::Distance.between_airports(pohnpei.airports.first, micronesia.airports.last)) / 100.0 * micronesia.populations.first.population / 12.0
 
-    assert actual == expected
+    assert_in_epsilon actual, expected, 0.000001
   end
 
   test "demand is reduced by an additional factor of 4 when the origin is not an island and the destination is international" do

--- a/test/models/calculation/tourist_demand_test.rb
+++ b/test/models/calculation/tourist_demand_test.rb
@@ -18,7 +18,7 @@ class Calculation::TouristDemandTest < ActiveSupport::TestCase
     )
     Market.new(
       name: "Pohnpei",
-      is_island: true,
+      is_island: false,
       country: "Micronesia",
       income: 100,
       airports: [airport_1],
@@ -40,7 +40,7 @@ class Calculation::TouristDemandTest < ActiveSupport::TestCase
     )
     Market.new(
       name: "Kosrae",
-      is_island: true,
+      is_island: false,
       country: "Micronesia",
       income: 100,
       airports: [airport_2],
@@ -72,7 +72,7 @@ class Calculation::TouristDemandTest < ActiveSupport::TestCase
     )
     Market.new(
       name: "Micronesia",
-      is_island: true,
+      is_island: false,
       country: "Micronesia",
       income: 100,
       airports: [airport_3a, airport_3b],
@@ -112,6 +112,8 @@ class Calculation::TouristDemandTest < ActiveSupport::TestCase
   end
 
   test "demand uses the island demand curve when the origin is an island" do
+    Market.find_by!(name: "Micronesia").update!(is_island: true)
+    
     micronesia = Market.find_by!(name: "Micronesia")
     kosrae = Market.find_by!(name: "Kosrae")
 
@@ -123,7 +125,7 @@ class Calculation::TouristDemandTest < ActiveSupport::TestCase
   end
 
   test "demand uses the mainland demand curve when the origin is not an island" do
-    Market.find_by!(name: "Micronesia").update!(is_island: false)
+    Market.find_by!(name: "Kosrae").update!(is_island: true)
 
     micronesia = Market.find_by!(name: "Micronesia")
     kosrae = Market.find_by!(name: "Kosrae")


### PR DESCRIPTION
Biggest changes:
DemandCurve no longer accepts a distance
Islands no longer have a flat part in their demand curve; shorter flights prioritized even more