### PR TITLE
Correct formula for slot prices

### DIFF
--- a/app/models/calculation/slot_rent.rb
+++ b/app/models/calculation/slot_rent.rb
@@ -1,5 +1,5 @@
 class Calculation::SlotRent
-  SCALE_CONSTANT = 0.00544331054
+  SCALE_CONSTANT = 0.00233284737
 
   def self.calculate(airport, game)
     gates = Gates.at_airport(airport, game)


### PR DESCRIPTION
Old formula neglected to consider that the price it was based off of was for daily landing rights, not weekly as slots are in the game.  Since it had been reduced by 1/3rd and then by 1/2 again, it was still too high.