### PR TITLE
Use + 1.day instead of comparing Date.today and Date.tomorrow

### DIFF
--- a/spec/views/airplanes/lease_information.html.erb_spec.rb
+++ b/spec/views/airplanes/lease_information.html.erb_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe "airplanes/lease_information", type: :feature do
   before(:each) do
     game = Game.create!(
       start_date: Date.today,
-      end_date: Date.tomorrow,
-      current_date: Date.tomorrow,
+      end_date: Date.today + 1.day,
+      current_date: Date.today + 1.day,
     )
     market = Market.create!(
       name: "AB",


### PR DESCRIPTION
Weird behavior with Date caused a test failure.  In my rails console: 
```
irb(main):001:0> Date.today
=> Sun, 09 Jan 2022
irb(main):002:0> Date.tomorrow
=> Tue, 11 Jan 2022
irb(main):003:0> Date.today + 1.day
=> Mon, 10 Jan 2022
```
Seems like a possible local date/UTC date mismatch given that it's Jan 9 local and Jan 10 UTC at the moment.  Since `+ 1.day` has the expected behavior, going with that for now